### PR TITLE
Fix missing UUID from ops.model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ops >= 1.2.0
+git+git://github.com/canonical/operator

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -16,3 +16,6 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(PrometheusScrapeTargetCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+
+    def test(self):
+        return True


### PR DESCRIPTION
This commit points the Python requirements to Canonical
github repository. This is because model.uuid is only
available through a recent commit to the Operator Framework.